### PR TITLE
Possible typo / bug-fix

### DIFF
--- a/src/app/component-utils.ts
+++ b/src/app/component-utils.ts
@@ -13,7 +13,7 @@ export function makeObservableFunction<T>(target: any, functionName: string) {
         } else {
             const args = new Array(len);
             for (let i = 0; i < len; i++) {
-                args[0] = arguments[i];
+                args[i] = arguments[i];
             }
             observer.next(args);
         }


### PR DESCRIPTION
I think that you have a typo in line 16   `args[0] = arguments[i];`   may cause all the arguments passed to the function to overwrite each other in the first item of args array, this can handle to error / bug if there are more than 1 argument passed to the function (event that you are handling / trasforming in an Observable)
